### PR TITLE
add .travis.yml to build processwarp on commit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+language: cpp
+
+compiler:
+  - clang
+
+before_install:
+  - sudo apt-get install clang git libssl-dev
+  - sudo add-apt-repository -y ppa:boost-latest/ppa
+  - sudo add-apt-repository -y ppa:kubuntu-ppa/backports
+  - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test -y
+  - sudo apt-get update -yqq
+  - sudo apt-get install -y libboost1.55-dev libboost-system1.55-dev libboost-date-time1.55-dev libboost-random1.55-dev
+  - sudo apt-get install -y cmake g++-4.8
+  - git clone --recurse-submodules https://github.com/socketio/socket.io-client-cpp.git
+  - cd socket.io-client-cpp
+  - sed -i -e 's/cmake_minimum_required(VERSION 3.1.0/cmake_minimum_required(VERSION 2.8.12/' ./CMakeLists.txt
+  - cmake -D CMAKE_CXX_FLAGS=-std=c++11 .
+  - make
+  - make install
+  - cd $TRAVIS_BUILD_DIR
+script:
+  - mkdir build
+  - cd build
+  - cmake -D SIO_DIR=$TRAVIS_BUILD_DIR/socket.io-client-cpp/build ..
+  - make
+  - ls -l src/core


### PR DESCRIPTION
コミットの度にTravis CIでビルドするように設定ファイルを追加。
Travis-CIへの登録とリポジトリへの有効化をTravis CIで設定してください。

テスト実行できるスクリプトがあれば、正常終了を確認するように追加できます。
ヘルプの出力はエラーで終了していてビルドが失敗扱いになるので仕方なくlsしています。